### PR TITLE
Python 3 portability

### DIFF
--- a/port23.py
+++ b/port23.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+
+os.chdir('./clairvoyante/')
+py_sripts = [p for p in os.listdir() if p.endswith('.py')]
+
+# use python provided 2to3 to convert package scripts to python3 versions
+subprocess.call(['2to3', '-nw']+py_sripts)
+
+# fix relative imports, overwrite to package folder
+for fn in os.listdir():
+    if fn.endswith('.py') and not fn.startswith('__'):
+        with open(fn, 'r') as f:
+            s = f.read()
+        s = s.replace('from . ', '')
+        with open(fn, 'w') as f:
+            f.write(s)
+        print('Fix import of %s' % fn)

--- a/port23.py
+++ b/port23.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
 
-os.chdir('./clairvoyante/')
+
+pkg_dir = os.path.dirname(os.path.abspath(__file__))+os.sep+'clairvoyante'
+os.chdir(pkg_dir)
 py_sripts = [p for p in os.listdir() if p.endswith('.py')]
 
 # use python provided 2to3 to convert package scripts to python3 versions
@@ -16,3 +18,4 @@ for fn in os.listdir():
         with open(fn, 'w') as f:
             f.write(s)
         print('Fix import of %s' % fn)
+


### PR DESCRIPTION
Using python shipped `2to3` to port the package to python3 is problematic because of the calling method used in callVarBam.py.

Excerpt of `2to3` log:
```
RefactoringTool: Refactored callVar.py
--- callVar.py	(original)
+++ callVar.py	(refactored)
@@ -2,18 +2,18 @@
 import os
 import time
 import argparse
-import param
+from . import param
 import logging
 import numpy as np
 from threading import Thread
 from math import log
```

The original python2 style import `import param` now becomes python3 style "relative import" `from . import param`. This is the desirable behavior when we use clairvoyante **as a package**, as the relative import correctly imports `param.py` intrapackage-ly, but not as a main script.

In `callVarBam.py`
```
        c.CVInstance = subprocess.Popen(\
            shlex.split("%s python %s --chkpnt_fn %s --call_fn %s --sampleName %s --threads %d" %\
                        (taskSet, CVBin, chkpnt_fn, call_fn, sampleName, numCpus) ),\
stdin=c.CTInstance.stdout, stdout=sys.stderr, stderr=sys.stderr, bufsize=8388608)
```
`callVar.py` is called by command line as the main script. `from . import` will fail. Python will error `cannot find name ...`, since this is no "package to be relative to".

The remedy is straight-forward, simply restore all relative imports back to python2 style (i.e. absolute import in python3).  `port23.py` is only tested on my Anaconda distribution python 3.6, but it should work on other python3.X as well.

Note: `port23.py` simply overwrites the original package, no backup files are produced.

This remedy is quick and dirty. For a more elegant solution, I would suggest rewriting a `multiprocessing` module process and call python function (`target=`callVar(...)`, something like this) directly in it, which takes advantage of python3 relative imports and works around the GIL as well.
